### PR TITLE
Add rate limiting to authentication and hotel routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "method-override": "^3.0.0",
     "mysql": "^2.18.1",
     "passport": "^0.4.1",
-    "passport-local": "^1.0.0"
+    "passport-local": "^1.0.0",
+    "express-rate-limit": "^5.3.0"
   },
   "devDependencies": {
     "dotenv": "^8.2.0",

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const passport = require('passport')
 const flash = require('express-flash')
 const session = require('express-session')
 const methodOverride = require('method-override')
+const rateLimit = require('express-rate-limit')
 
 const userDB = require('./users-database')
 const hotelDB = require('./hotels-database')
@@ -18,6 +19,11 @@ initializePassport(
 	passport,
 	email => userDB.getUserByEmail(email)
 )
+
+const limiter = rateLimit({
+	windowMs: 15 * 60 * 1000, // 15 minutes
+	max: 100 // limit each IP to 100 requests per windowMs
+})
 
 app.use(express.static(__dirname + '/public'))
 app.use(express.urlencoded({ extended: false }))
@@ -82,15 +88,15 @@ app.get('/contact', function (req, res) {
 	res.render('contact')
 })
 
-app.get('/hotels', async function (req, res) {
+app.get('/hotels', limiter, async function (req, res) {
 	res.render('hotels')
 })
 
-app.post('/hotels', async function (req, res) {
+app.post('/hotels', limiter, async function (req, res) {
 	res.redirect('hotels')
 })
 
-app.get('/hotelsdb', async function (req, res) {
+app.get('/hotelsdb', limiter, async function (req, res) {
 	const result = await hotelDB.all()
 	res.json(result)
 })
@@ -99,7 +105,7 @@ app.get('/hotelpage', function (req, res) {
 	res.render('hotelpage')
 })
 
-app.get('/roomsdb', async function (req, res) {
+app.get('/roomsdb', limiter, async function (req, res) {
 	const result = await roomDB.all(req.query.id)
 	res.json(result)
 })
@@ -127,13 +133,13 @@ app.post('/booknow', checkAuthenticated, async (req, res) => {
 	}
 })
 
-app.post('/login', checkNotAuthenticated, passport.authenticate('local', {
+app.post('/login', limiter, checkNotAuthenticated, passport.authenticate('local', {
 	successRedirect: '/',
 	failureRedirect: '/login',
 	failureFlash: true
 }))
 
-app.post('/signup', checkNotAuthenticated, async (req, res) => {
+app.post('/signup', limiter, checkNotAuthenticated, async (req, res) => {
 	try {
 		const hashedPassword = await bcrypt.hash(req.body.pass, 10)
 		const email = req.body.email


### PR DESCRIPTION
Fixes #34

Implement rate limiting to address the code scanning alert for missing rate limiting.

* **server.js**
  - Import `express-rate-limit` at the top of the file.
  - Create a rate limiter middleware with a window of 15 minutes and a max of 100 requests.
  - Apply the rate limiter middleware to the authentication routes.
  - Apply the rate limiter middleware to the hotel and room routes.

* **package.json**
  - Add `express-rate-limit` to the dependencies.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vladimirMocanu/Site_IP/issues/34?shareId=XXXX-XXXX-XXXX-XXXX).